### PR TITLE
preliminary support for OpenMP

### DIFF
--- a/bin/radical-synapse-sample
+++ b/bin/radical-synapse-sample
@@ -42,6 +42,8 @@ def run_samples (url, time, cpu_flops, cpu_time,
         if mem_rss:
             samples.append(['mem', float(n+1),  {'size'       : mem_rss}])
 
+    if not samples:
+        usage('no samples defined')
 
     info, ret, out = rs.emulate (samples=samples)
     pprint.pprint (info)

--- a/setup.py
+++ b/setup.py
@@ -230,8 +230,18 @@ def isgood(name):
 
 
 # -------------------------------------------------------------------------------
-c_ext = Extension("radical/synapse/atoms/_atoms" ,
-                  sources = glob.glob('src/radical/synapse/atoms/*.c'))
+if 'RADICAL_SYNAPSE_USE_OPENMP' in os.environ:
+    eca = ['-fopenmp', '-DRADICAL_SYNAPSE_USE_OPENMP=1']
+    ela = ['-lgomp']
+else:
+    eca = []
+    ela = []
+
+c_ext = Extension(name               = "radical/synapse/atoms/_atoms" ,
+                  sources            = glob.glob('src/radical/synapse/atoms/*.c'),
+                  extra_compile_args = eca, 
+                  extra_link_args    = ela)
+
 setup_args = {
     'name'               : name,
     'version'            : version,


### PR DESCRIPTION
RADICAL_SYNAPSE_USE_OPENMP must be set at installation time for
the synapse module to be compiled with OpenMP support.  Only gcc
support has been tested.  Only the assembly based compute emulator
evaluates these settings.

At runtime, OMP_NUM_THREADS can be used to define the number of
OpenMP threads used.